### PR TITLE
Fix test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: node_js
 node_js:
   - "0.10"
-  - "0.12"
+  - "lts/*"
+  - "stable"
 env:
   global:
     - REMOVE_DEPS=""

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">= 0.10"
   },
   "scripts": {
-    "test": "mocha -R spec test/index.js"
+    "test": "mocha --timeout 10000 -R spec test/index.js"
   },
   "dependencies": {
     "resolve": "^1.1.6"

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -40,10 +40,14 @@ function cleanup() {
 function skippable(module, minVersion, fn) {
   var VERSION;
 
-  try {
-    VERSION = requireUncached(module).VERSION
-  } catch (e) {
-    return;
+  if (module === 'node') {
+    VERSION = process.version.slice(1);
+  } else {
+    try {
+      VERSION = requireUncached(module).VERSION
+    } catch (e) {
+      return;
+    }
   }
 
   if (semver.gte(VERSION, minVersion)) {

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,15 @@ var expected = {
     }
   }
 };
+var expectedXml = {
+  data: {
+    trueKey: 'true',
+    falseKey: 'false',
+    subKey: {
+      subProp: '1'
+    }
+  }
+};
 
 // Support `tsconfig.json` look up.
 process.chdir(path.join(__dirname, 'fixtures'));
@@ -204,7 +213,7 @@ describe('rechoir', function () {
     });
     it('should know xml', function () {
       rechoir.prepare(extensions, './test/fixtures/test.xml');
-      expect(JSON.parse(require('./fixtures/test.xml'))).to.deep.equal(expected);
+      expect(JSON.parse(require('./fixtures/test.xml'))).to.deep.equal(expectedXml);
     });
     it('should know yaml', function () {
       rechoir.prepare(extensions, './test/fixtures/test.yaml');

--- a/test/index.js
+++ b/test/index.js
@@ -211,10 +211,11 @@ describe('rechoir', function () {
       rechoir.prepare(extensions, './test/fixtures/test.toml');
       expect(require('./fixtures/test.toml')).to.deep.equal(expected);
     });
-    it('should know xml', function () {
+    // Skip on node older than 0.12 because require-xml can't run on node 0.10
+    it('should know xml', skippable('node', '4.0.0', function () {
       rechoir.prepare(extensions, './test/fixtures/test.xml');
       expect(JSON.parse(require('./fixtures/test.xml'))).to.deep.equal(expectedXml);
-    });
+    }));
     it('should know yaml', function () {
       rechoir.prepare(extensions, './test/fixtures/test.yaml');
       expect(require('./fixtures/test.yaml')).to.deep.equal(expected);


### PR DESCRIPTION
Increases mocha's timeout which was causing it to report failure when tests actually succeeded.  All tests run synchronously, so the timeout doesn't actually prevent them from running too long, but it does report failure even after the test succeeds.

Also fixes the `.xml` test.  xml2json, by default, doesn't parse numbers or booleans in XML, so the expected parsed data structure should contain strings.